### PR TITLE
Add `npm run eslint` command

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+config/local.js
+public/scripts/bundle.js
+public/scripts/bundle.min.js

--- a/build/browserify.js
+++ b/build/browserify.js
@@ -54,7 +54,7 @@ module.exports = function(files, minify, watch, cb) {
 				utils.log('Browserify', 'Bundle successful.', 'success');
 			}
 			if(cb && _.isFunction(cb)) {
-				cb(err, stats);
+				cb();
 			}
 		})
 		.pipe(writeStream);

--- a/lib/auth/adapters/trello.js
+++ b/lib/auth/adapters/trello.js
@@ -1,5 +1,5 @@
-var OAuth1Strategy = require('passport-oauth1');
-var request = require('request');
+let OAuth1Strategy = require('passport-oauth1');
+let request = require('request');
 
 function TrelloStrategy(options, verify) {
 	OAuth1Strategy.call(this, Object.assign({
@@ -13,8 +13,8 @@ function TrelloStrategy(options, verify) {
 		request(`https://api.trello.com/1/members/me?key=${options.clientID}&token=${accessToken}`,
 			(err, response, body) => {
 				if (err) return done(err);
-				var profile = JSON.parse(body);
-				var namePieces = profile.fullName.split(' ');
+				let profile = JSON.parse(body);
+				let namePieces = profile.fullName.split(' ');
 				verify(req, accessToken, refreshToken, {
 					id: profile.id,
 					firstName: namePieces.shift(),

--- a/lib/auth/passport-setup.js
+++ b/lib/auth/passport-setup.js
@@ -46,7 +46,7 @@ module.exports = function(app) {
 			strategyConfig.callbackURL = strategyConfig.callbackURL || defaultCallback;
 			strategyConfig.passReqToCallback = true;
 			
-			var strategy = new adapter.strategy(strategyConfig, function(req, accessToken, refreshToken, profile, done) {
+			let strategy = new adapter.strategy(strategyConfig, function(req, accessToken, refreshToken, profile, done) {
 				adapter.translateProfile(accessToken, refreshToken, profile, function(err, profileData) {
 					if(err) {
 						return done(err);

--- a/lib/middleware/validate-auth-profile.js
+++ b/lib/middleware/validate-auth-profile.js
@@ -1,4 +1,4 @@
-var config = require('../config');
+let config = require('../config');
 module.exports = function(req, res, next) {
 	if(!req.session.hasOwnProperty('_auth_profile')) {
 		return res.redirect('/auth/error');

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "node ./bin/config --check-local && node --use_strict ./bin/build --watch --scripts --styles --server",
     "config": "node ./bin/config",
     "build": "NODE_ENV=production node --use_strict ./bin/build --scripts --styles --minify",
-    "heroku-postbuild": "node --use_strict ./bin/heroku-postbuild"
+    "heroku-postbuild": "node --use_strict ./bin/heroku-postbuild",
+    "eslint": "eslint ./"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
1. Allow contributors to easily find code style errors by running `npm run eslint`.
2. Fix a few eslint errors so that the project is clean
