### PR TITLE
Update README.md to fix a small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Perk Framework
 
-## Perk is an well [documented](http://perkframework.com) set of tools for building node web applications.
+## Perk is a well [documented](http://perkframework.com) set of tools for building node web applications.
 
 The goal of Perk is first and foremost to provide a well documented set of tools for building node web applications. Perk also aims to get you up and running quickly, while still providing you the flexibility to build production ready node apps. With these goals in mind, Perk is built on top of a series of robust, well supported libraries that have stood the test of time: [Passport](http://passportjs.org/), [Express](http://expressjs.com/), [Redis](http://redis.io/), and [Knex](http://knexjs.org/). These libraries are not hidden from view. You're 100% in control to swap one out here or there if you find a better tool for the job.
 


### PR DESCRIPTION
Change "an" to "a" to make it grammatically correct.

Before: "Perk is an well documented set of tools for building node web applications."
Proposed: "Perk is a well documented set of tools for building node web applications."
