### PR TITLE
Add the ability to configure user and authentication table columns

### DIFF
--- a/config/auth.js
+++ b/config/auth.js
@@ -1,50 +1,66 @@
 module.exports = {
-	local: {
-		saltRounds: 10,
-		registerRedirect: '/dashboard',
-		loginRedirect: '/dashboard'
+	columns: {
+		user: {
+			email: 'email',
+			firstName: 'firstName',
+			lastName: 'lastName'
+		},
+		authentication: {
+			type: 'type',
+			identifier: 'identifier',
+			password: 'password',
+			data: 'data',
+			userId: 'userId'
+		}
 	},
-	google: {
-		clientID: '{{ Google OAuth2 Client ID }}',
-		clientSecret: '{{ Google OAuth2 Client Secret }}',
-		// https://developers.google.com/gmail/api/auth/scopes
-		// https://developers.google.com/+/web/api/rest/oauth?hl=en
-		// https://developers.google.com/google-apps/calendar/auth
-		scope: [
-			// 'https://www.googleapis.com/auth/userinfo.email',
-			// 'https://www.googleapis.com/auth/userinfo.profile',
-			// 'https://www.googleapis.com/auth/calendar'
-		],
-		requireEmail: true,
-		redirect: '/dashboard'
-	},
-	facebook: {
-		clientID: '{{ Facebook OAuth2 Client ID }}',
-		clientSecret: '{{ Facebook OAuth2 Client Secret }}',
-		// https://developers.facebook.com/docs/facebook-login/permissions
-		scope: [
-			// 'email'
-		],
-		requireEmail: true,
-		redirect: '/dashboard'
-	},
-	trello: {
-		clientID: '{{ Trello Consumer Key }}',
-		clientSecret: '{{ Trello Consumer Secret }}',
-		scope: [
-			// 'read',
-			// 'write'
-		],
-		requireEmail: true,
-		redirect: '/dashboard'
-	},
-	github: {
-		clientID: '{{ Github Auth ClientID }}',
-		clientSecret: '{{ Github Auth Client Secret }}',
-		scope: [ 
-			//'user:email',
-		],
-		requireEmail: true,
-		redirect: '/dashboard'
+	adapters: {
+		local: {
+			saltRounds: 10,
+			registerRedirect: '/dashboard',
+			loginRedirect: '/dashboard'
+		},
+		google: {
+			clientID: '{{ Google OAuth2 Client ID }}',
+			clientSecret: '{{ Google OAuth2 Client Secret }}',
+			// https://developers.google.com/gmail/api/auth/scopes
+			// https://developers.google.com/+/web/api/rest/oauth?hl=en
+			// https://developers.google.com/google-apps/calendar/auth
+			scope: [
+				// 'https://www.googleapis.com/auth/userinfo.email',
+				// 'https://www.googleapis.com/auth/userinfo.profile',
+				// 'https://www.googleapis.com/auth/calendar'
+			],
+			requireEmail: true,
+			redirect: '/dashboard'
+		},
+		facebook: {
+			clientID: '{{ Facebook OAuth2 Client ID }}',
+			clientSecret: '{{ Facebook OAuth2 Client Secret }}',
+			// https://developers.facebook.com/docs/facebook-login/permissions
+			scope: [
+				// 'email'
+			],
+			requireEmail: true,
+			redirect: '/dashboard'
+		},
+		trello: {
+			clientID: '{{ Trello Consumer Key }}',
+			clientSecret: '{{ Trello Consumer Secret }}',
+			scope: [
+				// 'read',
+				// 'write'
+			],
+			requireEmail: true,
+			redirect: '/dashboard'
+		},
+		github: {
+			clientID: '{{ Github Auth ClientID }}',
+			clientSecret: '{{ Github Auth Client Secret }}',
+			scope: [
+				//'user:email',
+			],
+			requireEmail: true,
+			redirect: '/dashboard'
+		}
 	}
 };

--- a/lib/auth/adapters/facebook.js
+++ b/lib/auth/adapters/facebook.js
@@ -1,4 +1,5 @@
 const fb = require('fb');
+const config = require('../../config');
 module.exports = {
 	translateProfile: function(accessToken, refreshToken, profile, cb) {
 		fb.setAccessToken(accessToken);
@@ -22,12 +23,11 @@ module.exports = {
 				else if(pieces.length === 1) {
 					firstName = pieces[0];
 				}
-				return cb(null, {
-					id: profile.id,
-					firstName: firstName,
-					lastName: lastName,
-					email: res.email
-				});
+				const result = { id: profile.id };
+				result[config.auth.columns.user.firstName] = firstName;
+				result[config.auth.columns.user.lastName] = lastName;
+				result[config.auth.columns.user.email] = email;
+				return cb(null, result);
 			}
 		});
 	},

--- a/lib/auth/adapters/github.js
+++ b/lib/auth/adapters/github.js
@@ -1,3 +1,4 @@
+const config = require('../../config');
 module.exports = {
 	translateProfile: function(accessToken, refreshToken, profile, cb) {
 		const pieces = profile.displayName.split(' ');
@@ -9,12 +10,11 @@ module.exports = {
 		const email = profile.emails || [];
 		const primaryEmail = email.filter(data => data.primary);
 
-		return cb(null, {
-			id: profile.id,
-			firstName: firstName,
-			lastName: lastName,
-			email: primaryEmail.length ? primaryEmail[0].value : null
-		});
+		const result = { id: profile.id };
+		result[config.auth.columns.user.firstName] = firstName;
+		result[config.auth.columns.user.lastName] = lastName;
+		result[config.auth.columns.user.email] = primaryEmail.length ? primaryEmail[0].value : null;
+		return cb(null, result);
 	},
 	strategy: require('passport-github').Strategy,
 	packageName: 'passport-github'

--- a/lib/auth/adapters/google.js
+++ b/lib/auth/adapters/google.js
@@ -1,11 +1,10 @@
 module.exports = {
 	translateProfile: function(accessToken, refreshToken, profile, cb) {
-		return cb(null, {
-			id: profile.id,
-			firstName: profile.name.givenName,
-			lastName: profile.name.familyName,
-			email: profile.email
-		});	
+		const result = { id: profile.id };
+		result[config.auth.columns.user.firstName] = profile.name.givenName;
+		result[config.auth.columns.user.lastName] = profile.name.familyName;
+		result[config.auth.columns.user.email] = profile.email;
+		return cb(null, result);
 	},
 	strategy: require('passport-google-oauth2').Strategy,
 	packageName: 'passport-google-oauth2'

--- a/lib/auth/adapters/trello.js
+++ b/lib/auth/adapters/trello.js
@@ -15,12 +15,11 @@ function TrelloStrategy(options, verify) {
 				if (err) return done(err);
 				const profile = JSON.parse(body);
 				const namePieces = profile.fullName.split(' ');
-				verify(req, accessToken, refreshToken, {
-					id: profile.id,
-					firstName: namePieces.shift(),
-					lastName: namePieces.join(' '),
-					email: null
-				}, done);
+				const result = { id: profile.id };
+				result[config.auth.columns.user.firstName] = namePieces.shift();
+				result[config.auth.columns.user.lastName] = namePieces.join(' ');
+				result[config.auth.columns.user.email] = null;
+				verify(req, accessToken, refreshToken, result, done);
 			}
 		);
 	});

--- a/lib/auth/authenticator.js
+++ b/lib/auth/authenticator.js
@@ -20,7 +20,7 @@ module.exports = function(req, accessToken, profile, adapterName, done) {
 			});
 		}
 		// ASK USER FOR EMAIL
-		else if(!profile.email && config.auth[adapterName].requireEmail) {
+		else if(!profile[config.auth.columns.user.email] && config.auth.adapters[adapterName].requireEmail) {
 			req.session._auth_profile = profile;
 			req.session._auth_type = adapterName;
 			req.session._auth_access_token = accessToken;
@@ -29,21 +29,21 @@ module.exports = function(req, accessToken, profile, adapterName, done) {
 		// CREATE NEW USER
 		else {
 			bookshelf.transaction(function(t) {
-				let newUser = new UserModel({
-					firstName: profile.firstName,
-					lastName: profile.lastName,
-					email: profile.email
-				});
+				const userData = {};
+				userData[config.auth.columns.user.firstName] = profile[config.auth.columns.user.firstName];
+				userData[config.auth.columns.user.lastName] = profile[config.auth.columns.user.lastName];
+				userData[config.auth.columns.user.email] = profile[config.auth.columns.user.email];
+				let newUser = new UserModel(userData);
 				let newAuth = null;
 				newUser.save(null, {transacting: t})
 				.then(function(user) {
-					return AuthenticationModel.forge({
-						type: adapterName,
-						identifier: profile.id,
-						password: null,
-						data: {accessToken: accessToken},
-						userId: user.id
-					})
+					const authData = {};
+					authData[config.auth.columns.authentication.type] = adapterName;
+					authData[config.auth.columns.authentication.identifier] = profile.id;
+					authData[config.auth.columns.authentication.password] = null;
+					authData[config.auth.columns.authentication.data] = {accessToken: accessToken};
+					authData[config.auth.columns.authentication.userId] = user.id;
+					return AuthenticationModel.forge(authData)
 					.save(null, {transacting: t})
 					.then(function(newAuthModel) {
 						newAuth = newAuthModel;

--- a/lib/auth/create-auth.js
+++ b/lib/auth/create-auth.js
@@ -13,7 +13,7 @@ function rejectUnknown(err, reject) {
 
 module.exports = function(user, password, t) {
 	return new Promise(function(resolve, reject) {
-		bcrypt.genSalt(config.auth.local.saltRounds, function(err, salt) {
+		bcrypt.genSalt(config.auth.adapters.local.saltRounds, function(err, salt) {
 			if(err) {
 				return rejectUnknown(err, reject);
 			}
@@ -22,12 +22,12 @@ module.exports = function(user, password, t) {
 				if(err) {
 					return rejectUnknown(err, reject);
 				}
-				AuthModel.forge({
-					type: 'local',
-					identifier: user.get('email'),
-					password: hash,
-					userId: user.id
-				})
+				const authData = {};
+				authData[config.auth.columns.authentication.type] = 'local';
+				authData[config.auth.columns.authentication.identifier] = user.get(config.auth.columns.user.email);
+				authData[config.auth.columns.authentication.password] = hash;
+				authData[config.auth.columns.authentication.userId] = user.id;
+				AuthModel.forge(authData)
 				.save(null, {transacting: t})
 				.then(() => resolve(user))
 				.catch(err => {

--- a/lib/auth/no-dupe.js
+++ b/lib/auth/no-dupe.js
@@ -3,8 +3,10 @@ const Howhap = require('howhap');
 const config = require('../config');
 module.exports = function(email, t) {
 	return new Promise((resolve, reject) => {
+		const forgeData = {};
+		forgeData[config.auth.columns.user.email] = email;
 		UserModel
-		.forge({email: email})
+		.forge(forgeData)
 		.fetch({transacting: t})
 		.then(function(u) {
 			if(u) {

--- a/lib/auth/passport-setup.js
+++ b/lib/auth/passport-setup.js
@@ -11,7 +11,7 @@ const adapters = includeAll({
 });
 
 module.exports = function(app) {
-	if(!config.auth) return;
+	if(!config.auth.adapters) return;
 	passport.serializeUser(function(user, done) {
 		done(null, user.id);
 	});
@@ -27,7 +27,7 @@ module.exports = function(app) {
 		);
 	});
 
-	for(let adapterName in config.auth) {
+	for(let adapterName in config.auth.adapters) {
 		adapterName = adapterName.toLowerCase();
 		if(adapterName === 'local') {
 			continue;
@@ -37,7 +37,7 @@ module.exports = function(app) {
 		}
 		else {
 			let adapter = adapters[adapterName];
-			let strategyConfig = config.auth[adapterName];
+			let strategyConfig = config.auth.adapters[adapterName];
 			let defaultCallback = config.webserver.baseUrl + '/' + path.join(
 				'auth',
 				adapterName,
@@ -45,7 +45,7 @@ module.exports = function(app) {
 			);
 			strategyConfig.callbackURL = strategyConfig.callbackURL || defaultCallback;
 			strategyConfig.passReqToCallback = true;
-			
+
 			let strategy = new adapter.strategy(strategyConfig, function(req, accessToken, refreshToken, profile, done) {
 				adapter.translateProfile(accessToken, refreshToken, profile, function(err, profileData) {
 					if(err) {

--- a/lib/middleware/validate-auth-profile.js
+++ b/lib/middleware/validate-auth-profile.js
@@ -6,10 +6,10 @@ module.exports = function(req, res, next) {
 	if(!req.session.hasOwnProperty('_auth_type')) {
 		return res.redirect('/auth/error');
 	}
-	if(!config.auth.hasOwnProperty(req.session._auth_type)) {
+	if(!config.auth.adapters.hasOwnProperty(req.session._auth_type)) {
 		return res.redirect('/auth/error');
 	}
-	if(req.session._auth_profile.email && req.originalUrl !== '/auth/finish') {
+	if(req.session._auth_profile[config.auth.columns.user.email] && req.originalUrl !== '/auth/finish') {
 		return res.redirect('/auth/finish');
 	}
 	next();

--- a/lib/middleware/validate-auth-type.js
+++ b/lib/middleware/validate-auth-type.js
@@ -2,13 +2,13 @@ const config = require('../config');
 const _ = require('lodash');
 module.exports = function(req, res, next) {
 	let type = req.params.type.toLowerCase();
-	if(!config.auth || !_.isObject(config.auth)) {
+	if(!config.auth.adapters || !_.isObject(config.auth.adapters)) {
 		return res.status(500).json({
 			message: 'No defined authentication methods',
 			status: 500
 		});
 	}
-	if(!config.auth.hasOwnProperty(type)) {
+	if(!config.auth.adapters.hasOwnProperty(type)) {
 		return res.status(500).json({
 			message: '"'+type+'" is not a valid authentication method',
 			status: 400

--- a/lib/middleware/validate-local-credentials.js
+++ b/lib/middleware/validate-local-credentials.js
@@ -1,17 +1,15 @@
 const validator = require('validator');
-module.exports = function(req, res, next) {	
-	if(!req.body.email) {
-		res.error.add('auth.MISSING_EMAIL', 'email');
-		// errors.email = 'Please enter an email address';
+const config = require('../config');
+module.exports = function(req, res, next) {
+	if(!req.body[config.auth.columns.user.email]) {
+		res.error.add('auth.MISSING_EMAIL', config.auth.columns.user.email);
 	}
-	else if(!validator.isEmail(req.body.email)) {
-		res.error.add('auth.INVALID_EMAIL', 'email');
-		// errors.email = 'It looks like there\'s somthing wrong with that email address';
+	else if(!validator.isEmail(req.body[config.auth.columns.user.email])) {
+		res.error.add('auth.INVALID_EMAIL', config.auth.columns.user.email);
 	}
 
-	if(!req.body.password) {
-		res.error.add('auth.MISSING_PASSWORD', 'password');
-		// errors.password = 'Please enter a password';
+	if(!req.body[config.auth.columns.authentication.password]) {
+		res.error.add('auth.MISSING_PASSWORD', config.auth.columns.authentication.password);
 	}
 
 	// There is at least one error

--- a/test/routes/auth-login.post.js
+++ b/test/routes/auth-login.post.js
@@ -126,7 +126,7 @@ describe('POST /auth/login', function() {
 			});
 		});
 	});
-	
+
 	describe('responseFormat html', function() {
 		it('should throw an error if no email is supplied', function(done) {
 			request(app)

--- a/test/routes/auth-register.post.js
+++ b/test/routes/auth-register.post.js
@@ -121,7 +121,7 @@ describe('POST /auth/register', function() {
 			});
 		});
 
-		
+
 
 		it('should create a user if all necessary information is provided', function(done) {
 			request(app)
@@ -160,7 +160,7 @@ describe('POST /auth/register', function() {
 			});
 		});
 	});
-	
+
 	describe('responseFormat html', function() {
 		it('should throw an error if the user is already registered', function(done) {
 			request(app)
@@ -267,7 +267,7 @@ describe('POST /auth/register', function() {
 					let obj = list.toObject();
 					expect(obj.default).not.to.be.undefined;
 					expect(obj.default.message).to.equal('An unknown error occurred: {{message}}');
-					
+
 					cookie = res.headers['set-cookie'][0].split(';')[0];
 					let req = request(app).get('/dashboard?responseFormat=html');
 					req.cookies = cookie;


### PR DESCRIPTION
The idea here is that instead of being forced to use the specific column names that are gicen by default for the user and authentication tables, you will be able to configure these columns to be whatever you want.

I've updated `config/auth.js` to include an adapters section (what was there before) and a new columns section. The value of each property in the user and authentication sections within the columns section should correspond with the column name in these tables that you wish to use.

Once updating the config/auth.js file you will need to update the existing migration files or create a new migration to actually add those columns to your table. Once that's done you should be all set with your new column names.